### PR TITLE
Multiple groups

### DIFF
--- a/src/main/java/seedu/teachstack/logic/commands/GroupCommand.java
+++ b/src/main/java/seedu/teachstack/logic/commands/GroupCommand.java
@@ -4,12 +4,14 @@ import static java.util.Objects.requireNonNull;
 import static seedu.teachstack.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.teachstack.logic.parser.CliSyntax.PREFIX_STUDENTID;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import seedu.teachstack.commons.util.ToStringBuilder;
 import seedu.teachstack.logic.commands.exceptions.CommandException;
 import seedu.teachstack.model.Model;
 import seedu.teachstack.model.group.Group;
+import seedu.teachstack.model.person.Person;
 import seedu.teachstack.model.person.StudentId;
 
 
@@ -57,8 +59,21 @@ public class GroupCommand extends Command {
         String missingIds = "";
         requireNonNull(model);
         for (StudentId studentId : studentIds) {
+            //get the existing groups
+            Person currentPerson = model.getPerson(studentId);
+            Set<Group> newGroup = new HashSet<>();
+            Set<Group> existingGroup = currentPerson.getGroups();
+
+            for (Group group : group) {
+                newGroup.add(group);
+            }
+
+            for (Group group : existingGroup) {
+                newGroup.add(group);
+            }
+
             EditCommand.EditPersonDescriptor editPersonDescriptor = new EditCommand.EditPersonDescriptor();
-            editPersonDescriptor.setGroups(group);
+            editPersonDescriptor.setGroups(newGroup);
             EditCommand editCommand = new EditCommand(studentId, editPersonDescriptor);
             try {
                 editCommand.execute(model);

--- a/src/main/java/seedu/teachstack/logic/commands/GroupCommand.java
+++ b/src/main/java/seedu/teachstack/logic/commands/GroupCommand.java
@@ -61,7 +61,7 @@ public class GroupCommand extends Command {
         String missingIds = "";
         requireNonNull(model);
 
-        if (studentIds.size() == 0) {
+        if (group.size() == 0) {
             for (StudentId studentId : studentIds) {
                 clearGroups(model, studentId);
             }
@@ -71,17 +71,19 @@ public class GroupCommand extends Command {
         for (StudentId studentId : studentIds) {
             //get the existing groups
             Person currentPerson = model.getPerson(studentId);
+
+            if (currentPerson == null) {
+                missingIds += studentId + " ";
+                continue;
+            }
+
             Set<Group> newGroup = new HashSet<>();
             Set<Group> existingGroup = currentPerson.getGroups();
-
             newGroup.addAll(group);
             newGroup.addAll(existingGroup);
 
-            try {
-                addGroups(newGroup, model, studentId);
-            } catch (CommandException e) {
-                missingIds += studentId + " ";
-            }
+            addGroups(newGroup, model, studentId);
+
             //there's a dependency on EditCommand, but this for loop shouldn't cause EditCommand to throw any exception.
         }
         if (missingIds.equals("")) {

--- a/src/main/java/seedu/teachstack/logic/commands/GroupCommand.java
+++ b/src/main/java/seedu/teachstack/logic/commands/GroupCommand.java
@@ -36,9 +36,9 @@ public class GroupCommand extends Command {
 
     public static final String MESSAGE_GROUP_SUCCESS = "All students were added!";
     public static final String MESSAGE_CLEAR_SUCCESS = "All specified students were removed from any existing groups!";
-    public static final String STUDENTS_NOT_FOUND = "The following IDs were not found (and not added to the group): ";
+    public static final String STUDENTS_NOT_FOUND = "The command was not successful as these students were not found: ";
     private final Set<Group> group;
-    private final Set<Group> noGroup = new HashSet<>();
+    private final Set<Group> noGroup = new HashSet<>(); //Empty group
     private final Set<StudentId> studentIds;
 
     /**

--- a/src/main/java/seedu/teachstack/logic/parser/GroupCommandParser.java
+++ b/src/main/java/seedu/teachstack/logic/parser/GroupCommandParser.java
@@ -31,8 +31,6 @@ public class GroupCommandParser implements Parser<GroupCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, GroupCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_GROUP);
-        //set with one group. for compatibility with edit command.
         Set<Group> group = ParserUtil.parseGroups(argMultimap.getAllValues(PREFIX_GROUP));
         Set<StudentId> studentIds = ParserUtil.parseStudentIds(argMultimap.getAllValues(PREFIX_STUDENTID));
         return new GroupCommand(group, studentIds);

--- a/src/main/java/seedu/teachstack/logic/parser/GroupCommandParser.java
+++ b/src/main/java/seedu/teachstack/logic/parser/GroupCommandParser.java
@@ -26,7 +26,7 @@ public class GroupCommandParser implements Parser<GroupCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_GROUP, PREFIX_STUDENTID);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_GROUP, PREFIX_STUDENTID)
+        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENTID)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, GroupCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/teachstack/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/teachstack/model/util/SampleDataUtil.java
@@ -54,4 +54,11 @@ public class SampleDataUtil {
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * Returns a StudentId set containing the list of studentIds given.
+     */
+    public static Set<StudentId> getStudentIdSet(StudentId... studentIds) {
+        return Arrays.stream(studentIds)
+                .collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/seedu/teachstack/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/teachstack/model/util/SampleDataUtil.java
@@ -37,6 +37,7 @@ public class SampleDataUtil {
         };
     }
 
+
     public static ReadOnlyAddressBook getSampleAddressBook() {
         AddressBook sampleAb = new AddressBook();
         for (Person samplePerson : getSamplePersons()) {
@@ -57,7 +58,7 @@ public class SampleDataUtil {
     /**
      * Returns a StudentId set containing the list of studentIds given.
      */
-    public static Set<StudentId> getStudentIdSet(StudentId... studentIds) {
+    public static Set<StudentId> getStudentIdSetFromStudentIds(StudentId... studentIds) {
         return Arrays.stream(studentIds)
                 .collect(Collectors.toSet());
     }

--- a/src/test/java/seedu/teachstack/logic/commands/GroupCommandTest.java
+++ b/src/test/java/seedu/teachstack/logic/commands/GroupCommandTest.java
@@ -3,7 +3,7 @@ package seedu.teachstack.logic.commands;
 import static seedu.teachstack.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.teachstack.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.teachstack.model.util.SampleDataUtil.getGroupSet;
-import static seedu.teachstack.model.util.SampleDataUtil.getStudentIdSet;
+import static seedu.teachstack.model.util.SampleDataUtil.getStudentIdSetFromStudentIds;
 import static seedu.teachstack.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.HashSet;
@@ -30,8 +30,18 @@ public class GroupCommandTest {
      */
     @Test
     public void clear_validID_success() {
-        Person alice = new PersonBuilder(TypicalPersons.ALICE).build();
+        // Alice will have no groups
+        Person alice = new PersonBuilder(TypicalPersons.ALICE).withGroups().build();
+        GroupCommand groupCommand = new GroupCommand(getGroupSet(),
+                getStudentIdSetFromStudentIds(alice.getStudentId()));
 
+        // Should clear all groups
+        String expectedMessage = String.format(GroupCommand.MESSAGE_CLEAR_SUCCESS, Messages.format(alice));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getPerson(alice.getStudentId()), alice);
+
+        assertCommandSuccess(groupCommand, model, expectedMessage, expectedModel);
     }
 
     /**
@@ -45,7 +55,7 @@ public class GroupCommandTest {
 
         //change alice to group 99
         Person editedPerson = new PersonBuilder(TypicalPersons.ALICE).withGroups("Group 99").build();
-        Set<StudentId> studentIds = getStudentIdSet(TypicalPersons.ALICE.getStudentId());
+        Set<StudentId> studentIds = getStudentIdSetFromStudentIds(TypicalPersons.ALICE.getStudentId());
         GroupCommand groupCommand = new GroupCommand(editedPerson.getGroups(), studentIds);
 
         String expectedMessage = String.format(GroupCommand.MESSAGE_GROUP_SUCCESS, Messages.format(editedPerson));
@@ -74,7 +84,7 @@ public class GroupCommandTest {
     }
 
     /**
-     * Adds a student to a group. Then, adds that student to another group.
+     * Adds a student to a group 99. Then, adds that student to another group 100.
      * The student should be in both groups in the end.
      */
     @Test

--- a/src/test/java/seedu/teachstack/logic/commands/GroupCommandTest.java
+++ b/src/test/java/seedu/teachstack/logic/commands/GroupCommandTest.java
@@ -2,6 +2,7 @@ package seedu.teachstack.logic.commands;
 
 import static seedu.teachstack.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.teachstack.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.teachstack.model.util.SampleDataUtil.getGroupSet;
 import static seedu.teachstack.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.HashSet;
@@ -9,6 +10,7 @@ import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 import seedu.teachstack.logic.Messages;
+import seedu.teachstack.logic.commands.exceptions.CommandException;
 import seedu.teachstack.model.AddressBook;
 import seedu.teachstack.model.Model;
 import seedu.teachstack.model.ModelManager;
@@ -56,5 +58,29 @@ public class GroupCommandTest {
         GroupCommand groupCommand = new GroupCommand(editedPerson.getGroups(), studentIds);
 
         assertCommandFailure(groupCommand, model, GroupCommand.STUDENTS_NOT_FOUND + "A9999999Z ");
+    }
+
+    /**
+     * Adds a student to a group. Then, adds that student to another group.
+     * The student should be in both groups in the end.
+     */
+    @Test
+    public void execute_rememberPreviousGroups_success() throws CommandException {
+        //change alice to group 99 and 100
+        Person editedPerson = new PersonBuilder(TypicalPersons.ALICE).withGroups("Group 99", "Group 100").build();
+
+        HashSet<StudentId> studentIds = new HashSet<>();
+        studentIds.add(editedPerson.getStudentId());
+        GroupCommand addToGroup99 = new GroupCommand(getGroupSet("Group 99"), studentIds);
+        GroupCommand addToGroup100 = new GroupCommand(getGroupSet("Group 100"), studentIds);
+
+        String expectedMessage = String.format(GroupCommand.MESSAGE_GROUP_SUCCESS, Messages.format(editedPerson));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getPerson(editedPerson.getStudentId()), editedPerson); // Alice in group 99, 100
+
+        addToGroup99.execute(model);
+
+        assertCommandSuccess(addToGroup100, model, expectedMessage, expectedModel);
     }
 }

--- a/src/test/java/seedu/teachstack/logic/commands/GroupCommandTest.java
+++ b/src/test/java/seedu/teachstack/logic/commands/GroupCommandTest.java
@@ -3,9 +3,11 @@ package seedu.teachstack.logic.commands;
 import static seedu.teachstack.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.teachstack.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.teachstack.model.util.SampleDataUtil.getGroupSet;
+import static seedu.teachstack.model.util.SampleDataUtil.getStudentIdSet;
 import static seedu.teachstack.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,15 +26,26 @@ public class GroupCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     /**
+     * Clears the default ID of a person (in this case, Alice).
+     */
+    @Test
+    public void clear_validID_success() {
+        Person alice = new PersonBuilder(TypicalPersons.ALICE).build();
+
+    }
+
+    /**
      * Checks that Alice's group is correctly changed to group 99.
      */
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
 
+        //clear Alice's group
+        model.setPerson(TypicalPersons.ALICE, new PersonBuilder(TypicalPersons.ALICE).withGroups().build());
+
         //change alice to group 99
         Person editedPerson = new PersonBuilder(TypicalPersons.ALICE).withGroups("Group 99").build();
-        HashSet<StudentId> studentIds = new HashSet<>();
-        studentIds.add(editedPerson.getStudentId());
+        Set<StudentId> studentIds = getStudentIdSet(TypicalPersons.ALICE.getStudentId());
         GroupCommand groupCommand = new GroupCommand(editedPerson.getGroups(), studentIds);
 
         String expectedMessage = String.format(GroupCommand.MESSAGE_GROUP_SUCCESS, Messages.format(editedPerson));
@@ -66,6 +79,10 @@ public class GroupCommandTest {
      */
     @Test
     public void execute_rememberPreviousGroups_success() throws CommandException {
+
+        //clear Alice's group
+        model.setPerson(TypicalPersons.ALICE, new PersonBuilder(TypicalPersons.ALICE).withGroups().build());
+
         //change alice to group 99 and 100
         Person editedPerson = new PersonBuilder(TypicalPersons.ALICE).withGroups("Group 99", "Group 100").build();
 

--- a/src/test/java/seedu/teachstack/logic/commands/GroupCommandTest.java
+++ b/src/test/java/seedu/teachstack/logic/commands/GroupCommandTest.java
@@ -68,8 +68,6 @@ public class GroupCommandTest {
 
     /**
      * Checks that trying to modify the student ID of someone not in the list fails.
-     * Currently, GroupCommand will add found IDs to the specified group, while
-     * throwing an exception if there are any unfound IDs at all.
      */
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {

--- a/src/test/java/seedu/teachstack/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/teachstack/testutil/PersonBuilder.java
@@ -67,6 +67,7 @@ public class PersonBuilder {
 
     /**
      * Parses the {@code groups} into a {@code Set<Group>} and set it to the {@code Person} that we are building.
+     * If there are no args then the person is set to have no groups.
      */
     public PersonBuilder withGroups(String ... groups) {
         this.groups = SampleDataUtil.getGroupSet(groups);


### PR DESCRIPTION
Important changes to the group command: 

- The command no longer partially succeeds (i.e. add students with valid ID while not adding students with invalid ID within one command). It will either add everyone, or fail to add everyone to the specified groups.
  - In general, a CLI command should not partially succeed as it can lead to confusion. _(which groups were added? which groups were not?)_
- The command now supports adding students to multiple groups. 
  - If a student is already in a group, the new groups are added on top of the existing groups (contrary to the original AB3 implementation.)
- The command now supports having no group parameter. If that is the case, then the students with specified IDs have all their groups set to none (i.e. all their groups are removed). 