### PR TITLE
Modify storage to maintain changes between sessions

### DIFF
--- a/src/main/java/seedu/teachstack/logic/LogicManager.java
+++ b/src/main/java/seedu/teachstack/logic/LogicManager.java
@@ -65,6 +65,7 @@ public class LogicManager implements Logic {
         try {
             storage.saveAddressBook(model.getAddressBook());
             storage.saveArchivedBook(model.getArchivedBook());
+            storage.saveUserData();
         } catch (AccessDeniedException e) {
             throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
         } catch (IOException ioe) {

--- a/src/main/java/seedu/teachstack/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/teachstack/logic/commands/FindCommand.java
@@ -7,6 +7,7 @@ import seedu.teachstack.commons.util.ToStringBuilder;
 import seedu.teachstack.logic.Messages;
 import seedu.teachstack.model.Model;
 import seedu.teachstack.model.person.PersonInGroupPredicate;
+import seedu.teachstack.storage.JsonSerializableUserData;
 
 /**
  * Finds and lists all persons in address book who is a member of any of the specified groups.
@@ -31,6 +32,7 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+        JsonSerializableUserData.setLastRequestedFind(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/main/java/seedu/teachstack/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/teachstack/logic/commands/ListCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.teachstack.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.teachstack.model.Model;
+import seedu.teachstack.storage.JsonSerializableUserData;
 
 /**
  * Lists all persons in the address book to the user.
@@ -21,6 +22,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        JsonSerializableUserData.setLastRequestedFind(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/teachstack/model/ModelManager.java
+++ b/src/main/java/seedu/teachstack/model/ModelManager.java
@@ -27,6 +27,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Person> filteredArchivedPersons;
+    private static Predicate<Person> startingFilter = PREDICATE_SHOW_ALL_PERSONS;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -43,6 +44,7 @@ public class ModelManager implements Model {
         this.archivedBook.sort();
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        updateFilteredPersonList(startingFilter);
         filteredArchivedPersons = new FilteredList<>(this.archivedBook.getArchivedList());
     }
 
@@ -232,6 +234,14 @@ public class ModelManager implements Model {
     public void updateFilteredArchivedList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredArchivedPersons.setPredicate(predicate);
+    }
+
+    public static void setStartingFilter(Predicate<Person> predicate) {
+        startingFilter = predicate;
+    }
+
+    public static Predicate<Person> getStartingFilter() {
+        return startingFilter;
     }
 
     @Override

--- a/src/main/java/seedu/teachstack/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/teachstack/model/ReadOnlyUserPrefs.java
@@ -15,4 +15,5 @@ public interface ReadOnlyUserPrefs {
 
     Path getArchivedBookFilePath();
 
+    Path getUserDataFilePath();
 }

--- a/src/main/java/seedu/teachstack/model/UserPrefs.java
+++ b/src/main/java/seedu/teachstack/model/UserPrefs.java
@@ -16,6 +16,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     private GuiSettings guiSettings = new GuiSettings();
     private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
     private Path archivedBookFilePath = Paths.get("data", "archivedbook.json");
+    private Path userDataFilePath = Paths.get("data", "userdata.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -38,6 +39,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         setGuiSettings(newUserPrefs.getGuiSettings());
         setAddressBookFilePath(newUserPrefs.getAddressBookFilePath());
         setArchivedBookFilePath(newUserPrefs.getArchivedBookFilePath());
+        setUserDataFilePath(newUserPrefs.getUserDataFilePath());
     }
 
     public GuiSettings getGuiSettings() {
@@ -65,6 +67,15 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void setArchivedBookFilePath(Path archivedBookFilePath) {
         requireNonNull(archivedBookFilePath);
         this.archivedBookFilePath = archivedBookFilePath;
+    }
+
+    public Path getUserDataFilePath() {
+        return userDataFilePath;
+    }
+
+    public void setUserDataFilePath(Path userDataFilePath) {
+        requireNonNull(userDataFilePath);
+        this.userDataFilePath = userDataFilePath;
     }
 
     @Override

--- a/src/main/java/seedu/teachstack/model/person/Grade.java
+++ b/src/main/java/seedu/teachstack/model/person/Grade.java
@@ -3,6 +3,7 @@ package seedu.teachstack.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.teachstack.commons.util.AppUtil.checkArgument;
 
+import seedu.teachstack.storage.JsonSerializableUserData;
 
 /**
  * Represents a Student's grade in the address book.
@@ -21,8 +22,6 @@ public class Grade implements Comparable<Grade> {
             + VALID_GRADES;
 
     public final String value;
-
-
 
     /**
      * Constructs an {@code Grade}.
@@ -114,11 +113,12 @@ public class Grade implements Comparable<Grade> {
     }
 
     public static void modifyThreshold(Grade g) {
+        JsonSerializableUserData.setGradeThreshold(g);
         thresholdGrade = g;
     }
 
-    public String retrieveThreshold() {
-        return thresholdGrade.value;
+    public static Grade retrieveThreshold() {
+        return thresholdGrade;
     }
 
 }

--- a/src/main/java/seedu/teachstack/model/person/PersonInGroupPredicate.java
+++ b/src/main/java/seedu/teachstack/model/person/PersonInGroupPredicate.java
@@ -16,6 +16,10 @@ public class PersonInGroupPredicate implements Predicate<Person> {
         this.groups = groups;
     }
 
+    public Set<Group> getGroups() {
+        return groups;
+    }
+
     @Override
     public boolean test(Person person) {
         return groups.stream()

--- a/src/main/java/seedu/teachstack/storage/JsonAdaptedField.java
+++ b/src/main/java/seedu/teachstack/storage/JsonAdaptedField.java
@@ -1,0 +1,31 @@
+package seedu.teachstack.storage;
+
+import java.util.function.Predicate;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import seedu.teachstack.model.person.Person;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = JsonAdaptedGradeThreshold.class, name = "gradeThreshold"),
+        @JsonSubTypes.Type(value = JsonAdaptedLastFind.class, name = "lastRequestedFind")
+})
+public abstract class JsonAdaptedField {
+
+    @SuppressWarnings("unchecked")
+    public static JsonAdaptedField createField(String type, Object value) {
+        switch (type) {
+        case "gradeThreshold":
+            return new JsonAdaptedGradeThreshold(value.toString()); // value is of type Grade
+        case "lastRequestedFind":
+            return new JsonAdaptedLastFind((Predicate<Person>) value);
+        default:
+            // Should never happen
+            return null;
+        }
+    }
+
+    public abstract void performAction();
+}

--- a/src/main/java/seedu/teachstack/storage/JsonAdaptedGradeThreshold.java
+++ b/src/main/java/seedu/teachstack/storage/JsonAdaptedGradeThreshold.java
@@ -1,0 +1,20 @@
+package seedu.teachstack.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.teachstack.model.person.Grade;
+
+public class JsonAdaptedGradeThreshold extends JsonAdaptedField {
+    private final String gradeThreshold;
+
+    @JsonCreator
+    public JsonAdaptedGradeThreshold(@JsonProperty("gradeThreshold") String grade) {
+        gradeThreshold = grade;
+    }
+
+    @Override
+    public void performAction() {
+        Grade.modifyThreshold(new Grade(gradeThreshold));
+    }
+}

--- a/src/main/java/seedu/teachstack/storage/JsonAdaptedLastFind.java
+++ b/src/main/java/seedu/teachstack/storage/JsonAdaptedLastFind.java
@@ -1,0 +1,54 @@
+package seedu.teachstack.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.teachstack.commons.exceptions.IllegalValueException;
+import seedu.teachstack.model.Model;
+import seedu.teachstack.model.ModelManager;
+import seedu.teachstack.model.group.Group;
+import seedu.teachstack.model.person.Person;
+import seedu.teachstack.model.person.PersonInGroupPredicate;
+
+public class JsonAdaptedLastFind extends JsonAdaptedField {
+    private final List<JsonAdaptedGroup> groups = new ArrayList<>();
+
+    @JsonCreator
+    public JsonAdaptedLastFind(@JsonProperty("groups") List<JsonAdaptedGroup> groups) {
+        if (groups != null) {
+            this.groups.addAll(groups);
+        }
+    }
+
+    public JsonAdaptedLastFind(Predicate<Person> predicate) {
+        if (predicate instanceof PersonInGroupPredicate) {
+            PersonInGroupPredicate lastFind = (PersonInGroupPredicate) predicate;
+            this.groups.addAll(lastFind.getGroups().stream()
+                    .map(JsonAdaptedGroup::new)
+                    .collect(Collectors.toList()));
+        }
+    }
+
+    @Override
+    public void performAction() {
+        if (!groups.isEmpty()) {
+            try {
+                Set<Group> set = new HashSet<>();
+                for (JsonAdaptedGroup group : groups) {
+                    Group toModelType = group.toModelType();
+                    set.add(toModelType);
+                }
+                ModelManager.setStartingFilter(new PersonInGroupPredicate(set));
+            } catch (IllegalValueException ive) {
+                ModelManager.setStartingFilter(Model.PREDICATE_SHOW_ALL_PERSONS);
+            }
+        }
+    }
+}

--- a/src/main/java/seedu/teachstack/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/teachstack/storage/JsonAdaptedPerson.java
@@ -34,8 +34,6 @@ class JsonAdaptedPerson {
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
      */
     @JsonCreator
-
-
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("studentId") String studentId,
             @JsonProperty("email") String email,
             @JsonProperty("grade") String grade, @JsonProperty("groups") List<JsonAdaptedGroup> groups) {

--- a/src/main/java/seedu/teachstack/storage/JsonSerializableUserData.java
+++ b/src/main/java/seedu/teachstack/storage/JsonSerializableUserData.java
@@ -1,0 +1,56 @@
+package seedu.teachstack.storage;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import seedu.teachstack.model.ModelManager;
+import seedu.teachstack.model.person.Grade;
+import seedu.teachstack.model.person.Person;
+
+/**
+ * A user data file that is serializable to JSON format.
+ */
+@JsonRootName(value = "userdata")
+public class JsonSerializableUserData {
+    private static Grade gradeThreshold = Grade.retrieveThreshold();
+    private static Predicate<Person> lastRequestedFind = ModelManager.getStartingFilter();
+    @JsonProperty("fields")
+    private final List<JsonAdaptedField> fields = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonSerializableUserData} with the current fields.
+     */
+    @JsonCreator
+    public JsonSerializableUserData() {
+        fields.addAll(Arrays.stream(this.getClass().getDeclaredFields())
+                .filter(f -> !f.getType().equals(List.class))
+                .map(f -> {
+                    try {
+                        return JsonAdaptedField.createField(f.getName(), f.get(this));
+                    } catch (IllegalAccessException iae) {
+                        // Should not happen as we are accessing the same class
+                        return null;
+                    }
+                })
+                .collect(Collectors.toList()));
+    }
+
+    public List<JsonAdaptedField> toFields() {
+        return fields;
+    }
+
+    public static void setGradeThreshold(Grade grade) {
+        gradeThreshold = grade;
+    }
+
+    public static void setLastRequestedFind(Predicate<Person> predicate) {
+        lastRequestedFind = predicate;
+    }
+}

--- a/src/main/java/seedu/teachstack/storage/JsonUserDataStorage.java
+++ b/src/main/java/seedu/teachstack/storage/JsonUserDataStorage.java
@@ -1,0 +1,79 @@
+package seedu.teachstack.storage;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import seedu.teachstack.commons.core.LogsCenter;
+import seedu.teachstack.commons.exceptions.DataLoadingException;
+import seedu.teachstack.commons.util.FileUtil;
+import seedu.teachstack.commons.util.JsonUtil;
+
+/**
+ * A class to access user data stored as a json file on the hard disk.
+ */
+public class JsonUserDataStorage implements UserDataStorage {
+
+    private static final Logger logger = LogsCenter.getLogger(JsonUserDataStorage.class);
+
+    private Path filePath;
+
+    public JsonUserDataStorage(Path filePath) {
+        this.filePath = filePath;
+    }
+
+    public Path getUserDataFilePath() {
+        return filePath;
+    }
+
+    @Override
+    public Optional<JsonSerializableUserData> readUserData() throws DataLoadingException {
+        return readUserData(filePath);
+    }
+
+    /**
+     * Similar to {@link #readUserData()}.
+     *
+     * @param filePath location of the data. Cannot be null.
+     * @throws DataLoadingException if loading the data from storage failed.
+     */
+    public Optional<JsonSerializableUserData> readUserData(Path filePath) throws DataLoadingException {
+        requireNonNull(filePath);
+
+        Optional<JsonSerializableUserData> jsonUserData = JsonUtil.readJsonFile(
+                filePath, JsonSerializableUserData.class);
+        if (!jsonUserData.isPresent()) {
+            return Optional.empty();
+        }
+
+        setFields(jsonUserData.get());
+        return Optional.of(jsonUserData.get());
+    }
+
+    @Override
+    public void saveUserData() throws IOException {
+        saveUserData(filePath);
+    }
+
+    /**
+     * Similar to {@link #saveUserData()}.
+     *
+     * @param filePath location of the data. Cannot be null.
+     */
+    public void saveUserData(Path filePath) throws IOException {
+        requireNonNull(filePath);
+
+        FileUtil.createIfMissing(filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableUserData(), filePath);
+    }
+
+    public void setFields(JsonSerializableUserData data) {
+        logger.info(data.toFields().get(0).toString());
+        for (JsonAdaptedField field : data.toFields()) {
+            field.performAction();
+        }
+    }
+}

--- a/src/main/java/seedu/teachstack/storage/Storage.java
+++ b/src/main/java/seedu/teachstack/storage/Storage.java
@@ -13,7 +13,7 @@ import seedu.teachstack.model.UserPrefs;
 /**
  * API of the Storage component
  */
-public interface Storage extends AddressBookStorage, ArchivedBookStorage, UserPrefsStorage {
+public interface Storage extends AddressBookStorage, ArchivedBookStorage, UserPrefsStorage, UserDataStorage {
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataLoadingException;
@@ -39,4 +39,12 @@ public interface Storage extends AddressBookStorage, ArchivedBookStorage, UserPr
     @Override
     void saveArchivedBook(ReadOnlyArchivedBook archivedBook) throws IOException;
 
+    @Override
+    Path getUserDataFilePath();
+
+    @Override
+    Optional<JsonSerializableUserData> readUserData() throws DataLoadingException;
+
+    @Override
+    void saveUserData() throws IOException;
 }

--- a/src/main/java/seedu/teachstack/storage/StorageManager.java
+++ b/src/main/java/seedu/teachstack/storage/StorageManager.java
@@ -20,15 +20,17 @@ public class StorageManager implements Storage {
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
     private AddressBookStorage addressBookStorage;
     private ArchivedBookStorage archivedBookStorage;
+    private UserDataStorage userDataStorage;
     private UserPrefsStorage userPrefsStorage;
 
     /**
      * Creates a {@code StorageManager} with the given {@code AddressBookStorage} and {@code UserPrefStorage}.
      */
     public StorageManager(AddressBookStorage addressBookStorage, ArchivedBookStorage archivedBookStorage,
-                          UserPrefsStorage userPrefsStorage) {
+                          UserDataStorage userDataStorage, UserPrefsStorage userPrefsStorage) {
         this.addressBookStorage = addressBookStorage;
         this.archivedBookStorage = archivedBookStorage;
+        this.userDataStorage = userDataStorage;
         this.userPrefsStorage = userPrefsStorage;
     }
 
@@ -48,7 +50,6 @@ public class StorageManager implements Storage {
     public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException {
         userPrefsStorage.saveUserPrefs(userPrefs);
     }
-
 
     // ================ AddressBook methods ==============================
 
@@ -106,5 +107,34 @@ public class StorageManager implements Storage {
     public void saveArchivedBook(ReadOnlyArchivedBook archivedBook, Path filePath) throws IOException {
         logger.fine("Attempting to write to data file: " + filePath);
         archivedBookStorage.saveArchivedBook(archivedBook, filePath);
+    }
+
+    // ================ UserData methods ==============================
+
+    @Override
+    public Path getUserDataFilePath() {
+        return userDataStorage.getUserDataFilePath();
+    }
+
+    @Override
+    public Optional<JsonSerializableUserData> readUserData() throws DataLoadingException {
+        return readUserData(userDataStorage.getUserDataFilePath());
+    }
+
+    @Override
+    public Optional<JsonSerializableUserData> readUserData(Path filePath) throws DataLoadingException {
+        logger.fine("Attempting to read data from file: " + filePath);
+        return userDataStorage.readUserData(filePath);
+    }
+
+    @Override
+    public void saveUserData() throws IOException {
+        saveUserData(userDataStorage.getUserDataFilePath());
+    }
+
+    @Override
+    public void saveUserData(Path filePath) throws IOException {
+        logger.fine("Attempting to write to data file: " + filePath);
+        userDataStorage.saveUserData(filePath);
     }
 }

--- a/src/main/java/seedu/teachstack/storage/UserDataStorage.java
+++ b/src/main/java/seedu/teachstack/storage/UserDataStorage.java
@@ -1,0 +1,41 @@
+package seedu.teachstack.storage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import seedu.teachstack.commons.exceptions.DataLoadingException;
+
+/**
+ * Represents a storage for user-related fields.
+ */
+public interface UserDataStorage {
+
+    /**
+     * Returns the file path of the data file.
+     */
+    Path getUserDataFilePath();
+
+    /**
+     * Reads user data.
+     *
+     * @throws DataLoadingException if loading the data from storage failed.
+     */
+    Optional<JsonSerializableUserData> readUserData() throws DataLoadingException;
+
+    /**
+     * @see #getUserDataFilePath()
+     */
+    Optional<JsonSerializableUserData> readUserData(Path filePath) throws DataLoadingException;
+
+    /**
+     * Saves the user data to the storage.
+     * @throws IOException if there was any problem writing to the file.
+     */
+    void saveUserData() throws IOException;
+
+    /**
+     * @see #saveUserData()
+     */
+    void saveUserData(Path filePath) throws IOException;
+}


### PR DESCRIPTION
- Weak grade threshold is now maintained across sessions.
- This is done by creating a new JSON file userdata.json to keep track of certain fields that we want to be the same between sessions.
- This change should be flexible enough to accommodate any future changes we may want to keep track of. For example, the group filter is also now maintained across sessions (e.g. if `find gp/Group 1` was executed and the app is closed, the next time the app is opened the default list displayed will still have the Group 1 filter applied).