### PR TITLE
Fix unnessary arrow with 0 students

### DIFF
--- a/src/main/java/seedu/teachstack/logic/commands/SummaryCommand.java
+++ b/src/main/java/seedu/teachstack/logic/commands/SummaryCommand.java
@@ -57,17 +57,13 @@ public class SummaryCommand extends Command {
      * @param pieChartData
      */
     private void populate(ObservableList<Person> students, ObservableList<PieChart.Data> pieChartData) {
-        pieChartData.add(new PieChart.Data("A+", countStudentsWithGrade(students, "A+")));
-        pieChartData.add(new PieChart.Data("A", countStudentsWithGrade(students, "A")));
-        pieChartData.add(new PieChart.Data("A-", countStudentsWithGrade(students, "A-")));
-        pieChartData.add(new PieChart.Data("B+", countStudentsWithGrade(students, "B+")));
-        pieChartData.add(new PieChart.Data("B", countStudentsWithGrade(students, "B")));
-        pieChartData.add(new PieChart.Data("B-", countStudentsWithGrade(students, "B-")));
-        pieChartData.add(new PieChart.Data("C+", countStudentsWithGrade(students, "C+")));
-        pieChartData.add(new PieChart.Data("C", countStudentsWithGrade(students, "C")));
-        pieChartData.add(new PieChart.Data("D+", countStudentsWithGrade(students, "D+")));
-        pieChartData.add(new PieChart.Data("D", countStudentsWithGrade(students, "D")));
-        pieChartData.add(new PieChart.Data("F", countStudentsWithGrade(students, "F")));
+        String[] grades = {"A+", "A", "A-", "B+", "B", "B-", "C+", "C", "D+", "D", "F"};
+        for (String grade : grades) {
+            int count = countStudentsWithGrade(students, grade);
+            if (count > 0) {
+                pieChartData.add(new PieChart.Data(grade, count));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Removing the bug of arrow showing during summary command.
Now with 0 students, this is display: 

<img width="482" alt="image" src="https://github.com/AY2324S2-CS2103T-T09-1/tp/assets/44407952/c80adade-7cb9-4569-b0c1-92bb3ed99874">
